### PR TITLE
Optimised resources

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==2.5.0
 
       - name: Run nf-core lint
         env:

--- a/.github/workflows/sangerfulltest.yml
+++ b/.github/workflows/sangerfulltest.yml
@@ -11,7 +11,6 @@ jobs:
     name: Run LSF full size tests
     runs-on: ubuntu-latest
     steps:
-
       - name: Sets env vars for push
         run: |
           echo "REVISION=${{ github.sha }}" >> $GITHUB_ENV

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -12,6 +12,7 @@ lint:
     - .github/workflows/awsfulltest.yml
   files_unchanged:
     - LICENSE
+    - .gitattributes
     - .github/CONTRIBUTING.md
     - .github/ISSUE_TEMPLATE/bug_report.yml
     - .github/workflows/linting.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.0 - [date]
+
+### `Fixed`
+
+- Relative paths in the sample-sheet are now evaluated from the `--outdir` parameter
+- Memory usage rules for `samtools dict`
+- Appropriate use of `tabix`'s TBI and CSI indexing, depending on the sequence lengths
+
+### `Added`
+
+- `--outdir` is a _mandatory_ parameter
+
 ## v1.1.0 - [2022-10-07]
 
 Minor update that fixes a few bugs

--- a/bin/repeats_bed.py
+++ b/bin/repeats_bed.py
@@ -2,6 +2,7 @@
 # This script was originally conceived by @muffato
 
 import argparse
+import gzip
 import sys
 
 __doc__ = "This script prints a BED file of the masked regions a fasta file."
@@ -10,7 +11,7 @@ __doc__ = "This script prints a BED file of the masked regions a fasta file."
 def fasta_to_bed(fasta):
 
     in_gap = None
-    with open(sys.argv[1]) as fh:
+    with gzip.open(fasta, "rt") if fasta.endswith(".gz") else open(fasta) as fh:
         for line in fh:
             line = line[:-1]
             if line.startswith(">"):
@@ -41,7 +42,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("fasta", help="Input Fasta file.")
-    parser.add_argument("--version", action="version", version="%(prog)s 1.0")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.1")
     args = parser.parse_args()
 
     fasta_to_bed(args.fasta)

--- a/conf/base.config
+++ b/conf/base.config
@@ -16,10 +16,10 @@ process {
     memory = { check_max( 50.MB * task.attempt, 'memory' ) }
     time   = { check_max( 30.min * task.attempt, 'time' ) }
 
-    // samtools dict takes more memory on larger genomes
+    // samtools dict loads entire sequences in memory
     withName: 'SAMTOOLS_DICT' {
-        // 50 MB per 500 Mbp
-        memory = { check_max( 50.MB + 50.MB * task.attempt * Math.ceil(fasta.size() / 500000000), 'memory' ) }
+        // 50 MB per 50 Mbp
+        memory = { check_max( 50.MB + 50.MB * task.attempt * Math.ceil(meta.max_length / 50000000), 'memory' ) }
     }
 
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {

--- a/docs/output.md
+++ b/docs/output.md
@@ -70,7 +70,7 @@ the directory structure includes the assembly name, e.g. `gfLaeSulp1.1`, and all
 - `GCA_*.masked.ncbi.fa.gz`: Masked assembly in Fasta format, compressed with `bgzip` (whose index is `GCA_*.fa.gz.gzi`)
 - `GCA_*.masked.ncbi.fa.gz.fai`: `samtools faidx` index, which allows accessing any region of the assembly in constant time
 - `GCA_*.masked.ncbi.fa.dict`: `samtools dict` index, which allows identifying a sequence by its MD5 checksum
-- `GCA_*.masked.ncbi.bed.gz`: BED file with the coordinates of the regions masked by the NCBI pipeline, with accompanying `tabix` indices (`.csi` and `.tbi`)
+- `GCA_*.masked.ncbi.bed.gz`: BED file with the coordinates of the regions masked by the NCBI pipeline, with accompanying `tabix` indices (`.csi` and `.tbi`), depending on the sequence lengths
 
 ### Pipeline information
 

--- a/lib/NfcoreTemplate.groovy
+++ b/lib/NfcoreTemplate.groovy
@@ -223,12 +223,12 @@ class NfcoreTemplate {
         String.format(
             """\n
             ${dashedLine(monochrome_logs)}
-            ${colors.blue}   _____                                ${colors.green} _______   ${colors.red} _${colors.reset}
-            ${colors.blue}  / ____|                               ${colors.green}|__   __|  ${colors.red}| |${colors.reset}
-            ${colors.blue} | (___   __ _ _ __   __ _  ___ _ __ ${colors.reset}______${colors.green}| |${colors.yellow} ___ ${colors.red}| |${colors.reset}
-            ${colors.blue}  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|${colors.reset}______${colors.green}| |${colors.yellow}/ _ \\${colors.red}| |${colors.reset}
-            ${colors.blue}  ____) | (_| | | | | (_| |  __/ |         ${colors.green}| |${colors.yellow} (_) ${colors.red}| |____${colors.reset}
-            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|         ${colors.green}|_|${colors.yellow}\\___/${colors.red}}|______|${colors.reset}
+            ${colors.blue}   _____                               ${colors.green} _______   ${colors.red} _${colors.reset}
+            ${colors.blue}  / ____|                              ${colors.green}|__   __|  ${colors.red}| |${colors.reset}
+            ${colors.blue} | (___   __ _ _ __   __ _  ___ _ __ ${colors.reset} ___ ${colors.green}| |${colors.yellow} ___ ${colors.red}| |${colors.reset}
+            ${colors.blue}  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|${colors.reset}|___|${colors.green}| |${colors.yellow}/ _ \\${colors.red}| |${colors.reset}
+            ${colors.blue}  ____) | (_| | | | | (_| |  __/ |        ${colors.green}| |${colors.yellow} (_) ${colors.red}| |____${colors.reset}
+            ${colors.blue} |_____/ \\__,_|_| |_|\\__, |\\___|_|        ${colors.green}|_|${colors.yellow}\\___/${colors.red}|______|${colors.reset}
             ${colors.blue}                      __/ |${colors.reset}
             ${colors.blue}                     |___/${colors.reset}
             ${colors.purple}  ${workflow.manifest.name} v${workflow.manifest.version}${colors.reset}

--- a/lib/WorkflowInsdcdownload.groovy
+++ b/lib/WorkflowInsdcdownload.groovy
@@ -17,10 +17,14 @@ class WorkflowInsdcdownload {
                 System.exit(1)
             }
         } else {
-            if (!params.assembly_accession || !params.assembly_name || !params.outdir) {
-                log.error "Either --input, or --assembly_accession, --assembly_name, and --outdir must be provided"
+            if (!params.assembly_accession || !params.assembly_name) {
+                log.error "Either --input, or --assembly_accession and --assembly_name must be provided"
                 System.exit(1)
             }
+        }
+        if (!params.outdir) {
+            log.error "--outdir is mandatory"
+            System.exit(1)
         }
     }
 

--- a/modules/local/ncbi_download.nf
+++ b/modules/local/ncbi_download.nf
@@ -52,7 +52,8 @@ process NCBI_DOWNLOAD {
     wget ${ftp_path}/${remote_filename_stem}_genomic.fna.gz
     wget ${ftp_path}/md5checksums.txt
 
-    grep "\\(_assembly_report\\.txt\$\\|_assembly_stats\\.txt\$\\|_genomic\\.fna\\.gz\$\\)" md5checksums.txt > md5checksums_restricted.txt
+    grep "\\(_assembly_report\\.txt\$\\|_assembly_stats\\.txt\$\\|_genomic\\.fna\\.gz\$\\)" md5checksums.txt \
+        | grep -v "\\(_from_genomic\\.fna\\.gz\$\\)"> md5checksums_restricted.txt
     md5sum -c md5checksums_restricted.txt
     mv ${remote_filename_stem}_assembly_report.txt ${filename_assembly_report}
     mv ${remote_filename_stem}_assembly_stats.txt  ${filename_assembly_stats}

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
     ftp_root                   = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA"
 
     // Boilerplate options
-    outdir                     = null
+    outdir                     = 'results'
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
     email                      = null

--- a/subworkflows/local/params_check.nf
+++ b/subworkflows/local/params_check.nf
@@ -7,12 +7,12 @@ include { SAMPLESHEET_CHECK } from '../../modules/local/samplesheet_check'
 workflow PARAMS_CHECK {
 
     take:
-    inputs          // tuple, see below
+    samplesheet  // file
+    cli_params   // tuple, see below
+    outdir       // file output directory
 
 
     main:
-
-    def (samplesheet, assembly_accession, assembly_name, outdir) = inputs
 
     ch_versions = Channel.empty()
 
@@ -27,22 +27,16 @@ workflow PARAMS_CHECK {
             .map { [
                 it["assembly_accession"],
                 it["assembly_name"],
-                it["species_dir"],
+                it["species_dir"].startsWith("/") ? "" : outdir + "/",
             ] }
             .set { ch_inputs }
 
         ch_versions = ch_versions.mix(SAMPLESHEET_CHECK.out.versions)
 
     } else {
-
-        ch_inputs = Channel.of(
-            [
-                assembly_accession,
-                assembly_name,
-                outdir,
-            ]
-        )
-
+        // Add the other input channel in, as it's expected to have all the parameters in the right order
+        // except the output directory which must be appended
+        ch_inputs = ch_inputs.mix(cli_params.map { it + [outdir] } )
     }
 
 

--- a/subworkflows/sanger-tol/prepare_fasta.nf
+++ b/subworkflows/sanger-tol/prepare_fasta.nf
@@ -24,16 +24,53 @@ workflow PREPARE_FASTA {
     ch_samtools_faidx   = CUSTOM_GETCHROMSIZES (ch_compressed_fasta).fai
     ch_versions         = ch_versions.mix(CUSTOM_GETCHROMSIZES.out.versions)
 
+    // Read the .fai file, extract sequence statistics, and make an extended meta map
+    sequence_map        = ch_samtools_faidx.map {
+        meta, fai -> [meta, meta + get_sequence_map(fai)]
+    }
+    // Update all channels to use the extended meta map
+    fasta_gz            = ch_compressed_fasta.join(sequence_map).map { [it[2], it[1]]}
+    faidx               = ch_samtools_faidx.join(sequence_map).map { [it[2], it[1]]}
+    gzi                 = CUSTOM_GETCHROMSIZES.out.gzi.join(sequence_map).map { [it[2], it[1]]}
+    sizes               = CUSTOM_GETCHROMSIZES.out.sizes.join(sequence_map).map { [it[2], it[1]]}
+    expanded_fasta      = fasta.join(sequence_map).map { [it[2], it[1]]}
+
     // Generate Samtools dictionary
-    ch_samtools_dict    = SAMTOOLS_DICT (fasta).dict
+    ch_samtools_dict    = SAMTOOLS_DICT (expanded_fasta).dict
     ch_versions         = ch_versions.mix(SAMTOOLS_DICT.out.versions)
 
 
     emit:
-    fasta_gz = ch_compressed_fasta       // path: genome.fa.gz
-    faidx    = ch_samtools_faidx         // path: genome.fa.gz.fai
+    fasta_gz = fasta_gz                  // path: genome.fa.gz
+    faidx    = faidx                     // path: genome.fa.gz.fai
     dict     = ch_samtools_dict          // path: genome.fa.dict
-    gzi      = CUSTOM_GETCHROMSIZES.out.gzi     // path: genome.fa.gz.gzi
-    sizes    = CUSTOM_GETCHROMSIZES.out.sizes   // path: genome.fa.gz.sizes
+    gzi      = gzi                       // path: genome.fa.gz.gzi
+    sizes    = sizes                     // path: genome.fa.gz.sizes
     versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+}
+
+// Read the .fai file to extract the number of sequences, the maximum and total sequence length
+// Inspired from https://github.com/nf-core/rnaseq/blob/3.10.1/lib/WorkflowRnaseq.groovy
+def get_sequence_map(fai_file) {
+    def n_sequences = 0
+    def max_length = 0
+    def total_length = 0
+    fai_file.eachLine { line ->
+        def lspl   = line.split('\t')
+        def chrom  = lspl[0]
+        def length = lspl[1].toInteger()
+        n_sequences ++
+        total_length += length
+        if (length > max_length) {
+            max_length = length
+        }
+    }
+
+    def sequence_map = [:]
+    sequence_map.n_sequences = n_sequences
+    sequence_map.total_length = total_length
+    if (n_sequences) {
+        sequence_map.max_length = max_length
+    }
+    return sequence_map
 }

--- a/workflows/insdcdownload.nf
+++ b/workflows/insdcdownload.nf
@@ -46,12 +46,14 @@ workflow INSDCDOWNLOAD {
     ch_versions = Channel.empty()
 
     PARAMS_CHECK (
-        [
-            params.input,
-            params.assembly_accession,
-            params.assembly_name,
-            params.outdir,
-        ]
+        params.input,
+        Channel.of(
+            [
+                params.assembly_accession,
+                params.assembly_name,
+            ]
+        ),
+        params.outdir,
     )
     ch_versions         = ch_versions.mix(PARAMS_CHECK.out.versions)
 

--- a/workflows/insdcdownload.nf
+++ b/workflows/insdcdownload.nf
@@ -73,7 +73,7 @@ workflow INSDCDOWNLOAD {
     )
     ch_versions         = ch_versions.mix(PREPARE_REPEAT_MASKED_FASTA.out.versions)
     PREPARE_REPEATS (
-        DOWNLOAD_GENOME.out.fasta_masked
+        PREPARE_REPEAT_MASKED_FASTA.out.fasta_gz
     )
     ch_versions         = ch_versions.mix(PREPARE_REPEATS.out.versions)
 


### PR DESCRIPTION
Mainly an import of the changes from https://github.com/sanger-tol/nf-core-pipeline/pull/18 . By the way, changes under `subworkflows/sanger-tol` are not shown by default (same behaviour as for changes under `modules/nf-core`)

Also in this pull-request:

- Pinned the version of `nf-core` to match the version of the template
- Made the linting tests pass
- Changed the way `--outdir` is used to match the other two download pipelines: it's now considered for relative paths given in the sample-sheet
- Fixed an error (wrong parameter name) in `lib/WorkflowInsdcdownload.groovy` and clarified that `--outdir` is mandatory
- Updated logo with a clearer hyphen in `sanger-ToL`
- Added the 130 exit code (used in MEMLIMIT) as a reason for retrying the job
- Updated `modules/local/ncbi_download.nf` to not be confused by annotation files (by the way, I should consider downloading these)


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/insdcdownload/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
